### PR TITLE
Remove private protection from performPenChange

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -800,7 +800,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    private func performPanChange(translation: CGPoint) -> Bool
+    func performPanChange(translation: CGPoint) -> Bool
     {
         var translation = translation
         


### PR DESCRIPTION
Remove private protection from performPenChange to allow scrolling both the line chart view and the bar chart view