### PR TITLE
remove private protection from performPenChange

### DIFF
--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -802,7 +802,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    func performPanChange(translation: CGPoint) -> Bool
+    open func performPanChange(translation: CGPoint) -> Bool
     {
         var translation = translation
         

--- a/Source/Charts/Charts/BarLineChartViewBase.swift
+++ b/Source/Charts/Charts/BarLineChartViewBase.swift
@@ -802,7 +802,7 @@ open class BarLineChartViewBase: ChartViewBase, BarLineScatterCandleBubbleChartD
         }
     }
     
-    private func performPanChange(translation: CGPoint) -> Bool
+    func performPanChange(translation: CGPoint) -> Bool
     {
         var translation = translation
         


### PR DESCRIPTION
remove private protection from performPenChange to allow scrolling both the line chart view and the bar chart view